### PR TITLE
Read devided json chunks by twitter streaming API

### DIFF
--- a/src/twitter.coffee
+++ b/src/twitter.coffee
@@ -54,6 +54,8 @@ exports.use = (robot) ->
  new Twitter robot
 
 
+partial = ''
+
 class TwitterStreaming extends EventEmitter
 
  self = @
@@ -109,6 +111,8 @@ class TwitterStreaming extends EventEmitter
    request.end()
 
    parseResponse = (data,callback) ->
+     data = partial + data
+     partial = ''
      while ((index = data.indexOf('\r\n')) > -1)
        json = data.slice(0, index)
        data = data.slice(index + 2)
@@ -118,3 +122,7 @@ class TwitterStreaming extends EventEmitter
              callback JSON.parse(json), null
           catch err
              console.log err
+
+     partial = data
+     if partial
+       console.log 'Response continuing...'


### PR DESCRIPTION
The twitter streaming API often separates a tweet into two chunks like below.
- The first chunk:

```
{"created_at":"Mon Apr 13 02:02:31 +0000 2015","id":999999999999999999,"id_str":"999999999999999999","text":"@xxx_bot Hou are you","source":"\u003ca href=\"https:\/\/about.twitter.com\/products\/tweetdeck\" rel=\"nofollow\"\u003eTweetDeck\u003c\/a\u003e","truncated":false,"in_reply_to_status_id":null,"in_reply_to_status_id_str":null,"in_reply_to_user_id":9999999999,"in_reply_to_user_id_str":"9999999999","in_reply_to_screen_name":"xxx_bot","user":{"id":9999999999,"id_str":"9999999999","name":"yyy_bot","screen_name":"yyy_bot","location":"Earth","url":null,"description":"description","protected":false,"verified":false,"followers_count":99,"friends_count":99,"li\r\n
```
- The second chunk:

```
sted_count":99,"favourites_count":99,"statuses_count":99,"created_at":"Sun Jan 01 00:00:00 +0000 2015","utc_offset":32400,"time_zone":"Tokyo","geo_enabled":false,"lang":"ja","contributors_enabled":false,"is_translator":false,"profile_background_color":"642D8B","profile_background_image_url":"http:\/\/abs.twimg.com\/images\/themes\/theme10\/bg.gif","profile_background_image_url_https":"https:\/\/abs.twimg.com\/images\/themes\/theme10\/bg.gif","profile_background_tile":true,"profile_link_color":"0D088F","profile_sidebar_border_color":"65B0DA","profile_sidebar_fill_color":"7AC3EE","profile_text_color":"3D1957","profile_use_background_image":true,"profile_image_url":"http:\/\/pbs.twimg.com\/profile_images\/9999999999\/a.jpg","profile_image_url_https":"https:\/\/pbs.twimg.com\/profile_images\/9999999999\/a.jpg","default_profile":false,"default_profile_image":false,"following":null,"follow_request_sent":null,"notifications":null},"geo":null,"coordinates":null,"place":null,"contributors":null,"retweet_count":0,"favorite_count":0,"entities":{"hashtags":[],"trends":[],"urls":[],"user_mentions":[{"screen_name":"xxx_bot","name":"xxx_bot","id":9999999999,"id_str":"9999999999","indices":[0,12]}],"symbols":[]},"favorited":false,"retweeted":false,"possibly_sensitive":false,"filter_level":"low","lang":"en","timestamp_ms":"1428890551791"}\r\n

```

Of course JSON.parse() detects error when reading the chunks, so, as a result, the tweet must got lost. 

This patch preserves the first chunk of the separated tweet, and concatenate them when receiving the second one.
